### PR TITLE
Fix double release of `CFDictionary` values on macOS

### DIFF
--- a/macos/macos.go
+++ b/macos/macos.go
@@ -114,7 +114,6 @@ func GenKeyPair(label, tag string, useBiometrics, accessibleWhenUnlockedOnly boo
 	defer C.CFRelease(C.CFTypeRef(keyAttrs))
 
 	publicKeyData := C.CFDataRef(C.CFDictionaryGetValue(keyAttrs, unsafe.Pointer(C.kSecValueData)))
-	defer C.CFRelease(C.CFTypeRef(publicKeyData))
 
 	return C.GoBytes(
 		unsafe.Pointer(C.CFDataGetBytePtr(publicKeyData)),
@@ -279,7 +278,6 @@ func extractPubKey(key C.SecKeyRef) ([]byte, error) {
 	if val == nilCFData {
 		return nil, fmt.Errorf("cannot extract public key")
 	}
-	defer C.CFRelease(C.CFTypeRef(val))
 
 	return C.GoBytes(
 		unsafe.Pointer(C.CFDataGetBytePtr(val)),


### PR DESCRIPTION
According to [The Get Rule](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-SW1) referenced in the `CFDictionaryGetValue` function [documentation](https://developer.apple.com/documentation/corefoundation/1516757-cfdictionarygetvalue?language=objc), the ownership of dictionary values belongs to dictionary itself.

Releasing this memory reference causes the program to `panic` when the dictionary is released later on. Additionally, I've also reviewed other instances of `CFRelease` in the code but did not find any other apparent issues.