### PR TITLE
Honor useBiometrics on macOS by gating keys with user presence

### DIFF
--- a/macos/macos.go
+++ b/macos/macos.go
@@ -41,12 +41,13 @@ const (
 )
 
 // GenKeyPair creates a key with the given label and tag.
-// useBiometrics and accessibleWhenUnlockedOnly are ignored,
-// they are present for API compatibility.
+// When useBiometrics is set the key requires user presence (Touch ID, or the device
+// passcode where biometrics is unavailable) to use.
+// accessibleWhenUnlockedOnly is ignored, it is present for API compatibility.
 // Returns public key raw data.
 func GenKeyPair(label, tag string, useBiometrics, accessibleWhenUnlockedOnly bool) ([]byte, error) {
 	protection := C.kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-	flags := C.kSecAccessControlPrivateKeyUsage
+	flags := accessControlFlags(useBiometrics)
 
 	cfTag, err := newCFData([]byte(tag))
 	if err != nil {
@@ -283,6 +284,14 @@ func extractPubKey(key C.SecKeyRef) ([]byte, error) {
 		unsafe.Pointer(C.CFDataGetBytePtr(val)),
 		C.int(C.CFDataGetLength(val)),
 	), nil
+}
+
+func accessControlFlags(useBiometrics bool) uint {
+	flags := uint(C.kSecAccessControlPrivateKeyUsage)
+	if useBiometrics {
+		flags |= uint(C.kSecAccessControlUserPresence)
+	}
+	return flags
 }
 
 func newCFData(d []byte) (C.CFDataRef, error) {

--- a/macos/macos_test.go
+++ b/macos/macos_test.go
@@ -1,0 +1,32 @@
+//go:build darwin
+// +build darwin
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package macos
+
+import "testing"
+
+func TestAccessControlFlags(t *testing.T) {
+	off := accessControlFlags(false)
+	on := accessControlFlags(true)
+
+	if on == off {
+		t.Error("accessControlFlags(true) should add the user-presence flag")
+	}
+	if on&off != off {
+		t.Errorf("accessControlFlags(true) = %d must preserve the base flags %d", on, off)
+	}
+}


### PR DESCRIPTION
GenKeyPair ignores useBiometrics parameter, this is a documented behaviour.

This PR change the behaviour for mac to implement a check for biometrics with fallback to password (user presence), this was implemented relaxed as not all darwin configurations will support Touch ID, e.g. Mac Mini with a non Touch ID keyboard. Tests were implemented to cover the new behaviour.